### PR TITLE
Bugfix: start at argc 1 (skip executable)

### DIFF
--- a/main.c
+++ b/main.c
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
     memset(path1, 0, PATH_MAX);
     char path2[PATH_MAX];
     memset(path2, 0, PATH_MAX);
-    for (int i = 0; i < argc; i++) {
+    for (int i = 1; i < argc; i++) {
         char *arg = argv[i];
         bool isConfig = false;
         if (*arg != '\0' && (*arg == '/' || *arg == '-')) {


### PR DESCRIPTION
The current code starts counting at the executable path (argv position 0). This means that running `/path/to/pak -u bla bla` results in an error: `cannot read pak file -u`.

This PR fixes this behaviour by starting to count at position 1.